### PR TITLE
Add Ender 3 Max Neo Printer

### DIFF
--- a/_printers/Ender3MaxNeo.json
+++ b/_printers/Ender3MaxNeo.json
@@ -58,7 +58,7 @@
       "op": "Custom",
       "searchfor": "DEFAULT_AXIS_STEPS_PER_UNIT",
       "mask": "{.*}",
-      "value": "{ 80.08, 80.17, 400, 98.75 }",
+      "value": "{ 80, 80, 400, 96 }",
       "comment": "Ender Configs"
     },
     {
@@ -143,7 +143,7 @@
     {
       "op": "CustomVal",
       "searchfor": "MESH_INSET",
-      "value": "10",
+      "value": "40",
       "comment": "MRiscoC Center mesh"
     },
     {
@@ -158,7 +158,7 @@
       "op": "Custom",
       "searchfor": "TRAMMING_POINT_XY",
       "mask": "{.*}",
-      "value": "{ { 35, 35 }, { 265, 35 }, { 265, 265 }, { 35, 265 } }"
+      "value": "{ { 40, 40 }, { 260, 40 }, { 260, 260 }, { 40, 260 } }"
     },
     {
       "op": "CustomVal",
@@ -168,19 +168,19 @@
     {
       "op": "CustomVal",
       "searchfor": "RETRACT_LENGTH",
-      "value": "3",
+      "value": "5",
       "comment": "MRiscoC Bowden"
     },
     {
       "op": "CustomVal",
       "searchfor": "RETRACT_FEEDRATE",
-      "value": "45",
+      "value": "40",
       "comment": "MRiscoC Bowden"
     },
     {
       "op": "CustomVal",
       "searchfor": "RETRACT_RECOVER_FEEDRATE",
-      "value": "8",
+      "value": "40",
       "comment": "MRiscoC Bowden"
     }
   ],

--- a/_printers/Ender3MaxNeo.json
+++ b/_printers/Ender3MaxNeo.json
@@ -42,23 +42,23 @@
     {
       "op": "CustomVal",
       "searchfor": "DEFAULT_bedKp",
-      "value": "198.96"
+      "value": "391.14"
     },
     {
       "op": "CustomVal",
       "searchfor": "DEFAULT_bedKi",
-      "value": " 38.80"
+      "value": "76.39"
     },
     {
       "op": "CustomVal",
       "searchfor": "DEFAULT_bedKd",
-      "value": "680.25"
+      "value": "1335.09"
     },
     {
       "op": "Custom",
       "searchfor": "DEFAULT_AXIS_STEPS_PER_UNIT",
       "mask": "{.*}",
-      "value": "{ 80.08, 80.17, 400, 101.3 }",
+      "value": "{ 80.08, 80.17, 400, 98.75 }",
       "comment": "Ender Configs"
     },
     {
@@ -89,7 +89,7 @@
       "op": "Custom",
       "searchfor": "NOZZLE_TO_PROBE_OFFSET",
       "mask": "{.*}",
-      "value": "{ -57, -20, -1.75 }",
+      "value": "{ -40, -12, -1.80 }",
       "comment": "MRiscoC BLTouch offset for support: https://www.thingiverse.com/thing:4605354 (z-offset = -1.80 mm)"
     },
     {
@@ -119,7 +119,7 @@
     {
       "op": "CustomVal",
       "searchfor": "X_MAX_POS",
-      "value": "300",
+      "value": "305",
       "comment": "MRiscoC Stock physical limit"
     },
     {
@@ -143,14 +143,14 @@
     {
       "op": "CustomVal",
       "searchfor": "MESH_INSET",
-      "value": "25",
+      "value": "10",
       "comment": "MRiscoC Center mesh"
     },
     {
       "op": "Custom",
       "searchfor": "NOZZLE_PARK_POINT",
       "mask": "{.*}",
-      "value": "{ (X_BED_SIZE + 10), (Y_MAX_POS - 10), 20 }"
+      "value": "{ -15, (Y_MAX_POS), 20 }"
     }
   ],
   "Configuration_adv.h": [
@@ -158,7 +158,7 @@
       "op": "Custom",
       "searchfor": "TRAMMING_POINT_XY",
       "mask": "{.*}",
-      "value": "{ { 60, 60 }, { 240, 60 }, { 240, 240 }, { 60, 240 } }"
+      "value": "{ { 35, 35 }, { 265, 35 }, { 265, 265 }, { 35, 265 } }"
     },
     {
       "op": "CustomVal",

--- a/_printers/Ender3MaxNeo.json
+++ b/_printers/Ender3MaxNeo.json
@@ -1,0 +1,195 @@
+{
+  "Configuration.h": [
+    {
+      "op": "CustomVal",
+      "searchfor": "TEMP_SENSOR_BED",
+      "value": "1",
+      "comment": "Ender Configs"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "HEATER_0_MINTEMP",
+      "value": "0",
+      "comment": "Ender Configs"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "BED_MINTEMP",
+      "value": "0",
+      "comment": "Ender Configs"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "BED_MAXTEMP",
+      "value": "120",
+      "comment": "Ender3V2 Configs"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "DEFAULT_Kp",
+      "value": "25.80"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "DEFAULT_Ki",
+      "value": "2.50"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "DEFAULT_Kd",
+      "value": " 66.64"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "DEFAULT_bedKp",
+      "value": "198.96"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "DEFAULT_bedKi",
+      "value": " 38.80"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "DEFAULT_bedKd",
+      "value": "680.25"
+    },
+    {
+      "op": "Custom",
+      "searchfor": "DEFAULT_AXIS_STEPS_PER_UNIT",
+      "mask": "{.*}",
+      "value": "{ 80.08, 80.17, 400, 101.3 }",
+      "comment": "Ender Configs"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "DEFAULT_XJERK",
+      "value": "8.0",
+      "comment": "Ender Configs"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "DEFAULT_YJERK",
+      "value": "8.0",
+      "comment": "Ender Configs"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "DEFAULT_ZJERK",
+      "value": "0.4",
+      "comment": "Ender Configs"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "DEFAULT_EJERK",
+      "value": "5.0",
+      "comment": "Ender Configs"
+    },
+    {
+      "op": "Custom",
+      "searchfor": "NOZZLE_TO_PROBE_OFFSET",
+      "mask": "{.*}",
+      "value": "{ -57, -20, -1.75 }",
+      "comment": "MRiscoC BLTouch offset for support: https://www.thingiverse.com/thing:4605354 (z-offset = -1.80 mm)"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "X_BED_SIZE",
+      "value": "300",
+      "comment": "MRiscoC Max usable bed size"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "Y_BED_SIZE",
+      "value": "300",
+      "comment": "MRiscoC Max usable bed size"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "X_MIN_POS",
+      "value": "-24",
+      "comment": "MRiscoC Stock physical limit"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "Y_MIN_POS",
+      "value": "-4",
+      "comment": "MRiscoC Stock physical limit"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "X_MAX_POS",
+      "value": "300",
+      "comment": "MRiscoC Stock physical limit"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "Y_MAX_POS",
+      "value": "300",
+      "comment": "MRiscoC Stock physical limit"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "Z_MAX_POS",
+      "value": "320",
+      "comment": "Ender Configs"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "FILAMENT_RUNOUT_DISTANCE_MM",
+      "value": "25",
+      "comment": "MRiscoC Customizable by menu"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "MESH_INSET",
+      "value": "25",
+      "comment": "MRiscoC Center mesh"
+    },
+    {
+      "op": "Custom",
+      "searchfor": "NOZZLE_PARK_POINT",
+      "mask": "{.*}",
+      "value": "{ (X_BED_SIZE + 10), (Y_MAX_POS - 10), 20 }"
+    }
+  ],
+  "Configuration_adv.h": [
+    {
+      "op": "Custom",
+      "searchfor": "TRAMMING_POINT_XY",
+      "mask": "{.*}",
+      "value": "{ { 60, 60 }, { 240, 60 }, { 240, 240 }, { 60, 240 } }"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "TRAMMING_SCREW_THREAD",
+      "value": "40"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "RETRACT_LENGTH",
+      "value": "3",
+      "comment": "MRiscoC Bowden"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "RETRACT_FEEDRATE",
+      "value": "45",
+      "comment": "MRiscoC Bowden"
+    },
+    {
+      "op": "CustomVal",
+      "searchfor": "RETRACT_RECOVER_FEEDRATE",
+      "value": "8",
+      "comment": "MRiscoC Bowden"
+    }
+  ],
+  "Version.h": [
+    {
+      "op": "Custom",
+      "searchfor": "MACHINE_NAME",
+      "mask": "\".+\"",
+      "value": "\"Ender 3 Max Neo\""
+    }
+  ]
+}


### PR DESCRIPTION
Add Ender 3 Max Neo printer configuration

Values are based on the values extracted from the stock firmware configurations

Tested on my Ender 3 Max Neo (Board Version 4.2.2, GD32F303RET6), compiled with STM32F103RE_creality (512K)

I enabled `#define RESTORE_LEVELING_AFTER_G28` based on a [discussion on Marlin](https://github.com/MarlinFirmware/Marlin/issues/23806#issuecomment-1057631924) about Z Offset issues. I haven't tested without it tbh to see if it's still an issue, but with it I can confirm there are no issues 

```
; My Stock Creality Configs 
Send: M503
Recv: echo:  G21    ; Units in mm (mm)
Recv:
Recv: echo:; Filament settings: Disabled
Recv: echo:  M200 S0 D1.75
Recv: echo:; Steps per unit:
Recv: echo: M92 X80.08 Y80.17 Z400.00 E101.30
Recv: echo:; Maximum feedrates (units/s):
Recv: echo:  M203 X500.00 Y500.00 Z10.00 E50.00
Recv: echo:; Maximum Acceleration (units/s2):
Recv: echo:  M201 X500.00 Y500.00 Z100.00 E5000.00
Recv: echo:; Acceleration (units/s2): P<print_accel> R<retract_accel> T<travel_accel>
Recv: echo:  M204 P500.00 R1000.00 T500.00
Recv: echo:; Advanced: B<min_segment_time_us> S<min_feedrate> T<min_travel_feedrate> X<max_x_jerk> Y<max_y_jerk> Z<max_z_jerk> E<max_e_jerk>
Recv: echo:  M205 B20000.00 S0.00 T0.00 X8.00 Y8.00 Z0.40 E5.00
Recv: echo:; Home offset:
Recv: echo:  M206 X0.00 Y0.00 Z0.00
Recv: echo:; Auto Bed Leveling:
Recv: echo:  M420 S1 Z10.00
Recv: echo:  G29 W I0 J0 Z-0.18850
Recv: echo:  G29 W I1 J0 Z0.00400
Recv: echo:  G29 W I2 J0 Z0.18300
Recv: echo:  G29 W I3 J0 Z0.45400
Recv: echo:  G29 W I4 J0 Z0.75300
Recv: echo:  G29 W I0 J1 Z-0.29450
Recv: echo:  G29 W I1 J1 Z-0.07350
Recv: echo:  G29 W I2 J1 Z0.12900
Recv: echo:  G29 W I3 J1 Z0.37900
Recv: echo:  G29 W I4 J1 Z0.65800
Recv: echo:  G29 W I0 J2 Z-0.33600
Recv: echo:  G29 W I1 J2 Z-0.12950
Recv: echo:  G29 W I2 J2 Z0.05150
Recv: echo:  G29 W I3 J2 Z0.27050
Recv: echo:  G29 W I4 J2 Z0.49150
Recv: echo:  G29 W I0 J3 Z-0.43600
Recv: echo:  G29 W I1 J3 Z-0.22550
Recv: echo:  G29 W I2 J3 Z-0.05700
Recv: echo:  G29 W I3 J3 Z0.13250
Recv: echo:  G29 W I4 J3 Z0.33200
Recv: echo:  G29 W I0 J4 Z-0.53450
Recv: echo:  G29 W I1 J4 Z-0.34350
Recv: echo:  G29 W I2 J4 Z-0.17050
Recv: echo:  G29 W I3 J4 Z0.01050
Recv: echo:  G29 W I4 J4 Z0.17300
Recv: echo:; Material heatup parameters:
Recv: echo:  M145 S0 H150.00 B60.00 F255
Recv: echo:  M145 S1 H240.00 B100.00 F255
Recv: echo:; PID settings:
Recv: echo:  M301 P25.80 I2.50 D66.64
Recv: echo:  M304 P198.96 I38.80 D680.25
Recv: echo:; Power-Loss Recovery:
Recv: echo:  M413 S1
Recv: echo:; Z-Probe Offset (mm):
Recv: echo:  M851 X-57.00 Y-20.00 Z-1.75
Recv: echo:; Filament load/unload lengths:
Recv: echo:  M603 L0.00 U100.00
Recv: ok
```