### PR TITLE
20250218 fix typo

### DIFF
--- a/_boards/SKRME3V2.json
+++ b/_boards/SKRME3V2.json
@@ -128,7 +128,7 @@
     "comment": "SKR MINIE3V2"
   },  
   {
-    "op": "Disabled",
+    "op": "Disable",
     "searchfor": "CONTROLLER_FAN_PIN"
   },
   {

--- a/_boards/SKRME3V2.json
+++ b/_boards/SKRME3V2.json
@@ -145,7 +145,7 @@
   {
     "op": "Disable",
     "searchfor": "ADAPTIVE_STEP_SMOOTHING",
-    "comment": "Workaround to fix interrrupt handling in SKR MINIE3V2"
+    "comment": "Workaround to fix interrupt handling in SKR MINIE3V2"
   }  
 ],
 "Version.h" : [


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

When trying to create configurations for board: `SKRME3V2`, I get error:

```
Configurations generator script for the Professional Firmware
Author: Miguel A. Risco Castillo (c) 2022

-Process Ender3-SKRME3V2-BLTUBL-CR10DSPLY-T13/Configuration.h
-Process Ender3-SKRME3V2-BLTUBL-CR10DSPLY-T13/Configuration_adv.h
>>>> Invalid operation: Disabled
>>>> While processing file: _boards/SKRME3V2.json

An error was found while processing your request
```

I found that this `Disabled` line should just be `Disable` https://github.com/mriscoc/Special_Configurations/blob/5b8e0a3b797a516d00b328bcb80629091c8ca051/_boards/SKRME3V2.json#L131

```json
  {
    "op": "Disabled",
    "searchfor": "CONTROLLER_FAN_PIN"
  },
```

```diff
-    "op": "Disabled",
+    "op": "Disable",
```

In addition to fixing this issue that prevented me from building the configurations for this board. I also noticed a typo for `interrrupt` https://github.com/mriscoc/Special_Configurations/blob/5b8e0a3b797a516d00b328bcb80629091c8ca051/_boards/SKRME3V2.json#L148

This one does not prevent the usage of this tool, its just another typo I found.

```diff
-    "comment": "Workaround to fix interrrupt handling in SKR MINIE3V2"
+    "comment": "Workaround to fix interrupt handling in SKR MINIE3V2"
```


### Requirements

The issue is in the `_boards/SKRME3V2.json` file

### Benefits

I was unable to build the configurations for board: `SKRME3V2`

I was able to build the configurations after making this fix.

### Configurations

```python
#!/usr/bin/python

import CreateConfigs
CreateConfigs.Generate('Ender3-SKRME3V2-BLTUBL-CR10DSPLY-T13',['Ender3','SKRME3V2','BLT','UBL','CR10DSPLY','T13'])
```
